### PR TITLE
Update withTheme.js

### DIFF
--- a/src/withTheme.js
+++ b/src/withTheme.js
@@ -4,7 +4,7 @@ import useTheme from './useTheme'
 
 export default (component) => (
   forwardRef((ownProps, ref) => {
-    const { theme } = useTheme()
+    const theme = useTheme()
     return createElement(component, { ...ownProps, theme, ref })
   })
 )


### PR DESCRIPTION
the theme object is returned directly from useTheme, not an object with a key of theme, so destructuring to { theme } is creating a theme.theme property, which is not correctly referencing the context's theme property. This fixes it